### PR TITLE
Exception due to closed content stream.

### DIFF
--- a/src/main/java/com/github/caldav4j/util/MethodUtil.java
+++ b/src/main/java/com/github/caldav4j/util/MethodUtil.java
@@ -4,18 +4,12 @@ import com.github.caldav4j.exceptions.*;
 import com.github.caldav4j.exceptions.ResourceNotFoundException.IdentifierType;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.util.EntityUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 /**
  * Method Utilities
  */
 public class MethodUtil {
-	private static final Logger log = LoggerFactory.getLogger(MethodUtil.class);
-	
+
 	/**
 	 * Throws various exceptions depending on the status &gt;= 400 of the given method
 	 * @param method Method causing error
@@ -26,14 +20,7 @@ public class MethodUtil {
 	public static int StatusToExceptions(HttpRequestBase method, HttpResponse response) throws CalDAV4JException {
 		if (method != null && response != null) {
 			int status = response.getStatusLine().getStatusCode();
-			if (log.isDebugEnabled()) {
-				try {
-					log.debug("Server returned " + EntityUtils.toString(response.getEntity(),"UTF-8"));
-				} catch (IOException e) {
-					throw new CalDAV4JException("Error retrieving server response", e);
-				}
-			}
-			if (status >= 300) {				
+			if (status >= 300) {
 				switch (status) {
 				case CalDAVStatus.SC_CONFLICT:
 					throw new ResourceOutOfDateException("Conflict accessing: " + method.getURI() );


### PR DESCRIPTION
Usage of EntityUtils.toString(response.getEntity() is causing an exception in a UnitTest (`PutGetTest#testAddRemoveCalendarResource`) when the log is enabled for TRACE due to closed content stream of response entity and the only reason to check if the debug is enabled is to print the entity's content.