### PR TITLE
query generator: ensure 'allprop' is handled correctly independently of used setter

### DIFF
--- a/src/main/java/com/github/caldav4j/util/GenerateQuery.java
+++ b/src/main/java/com/github/caldav4j/util/GenerateQuery.java
@@ -8,7 +8,9 @@ import com.github.caldav4j.model.request.*;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.fortuna.ical4j.model.Calendar;
@@ -59,7 +61,6 @@ public class GenerateQuery {
     private List<String> filterComponentProperties = new ArrayList<>();
     private Date timeRangeStart = null;
     private Date timeRangeEnd = null;
-    private boolean allProp = true;
     private boolean noCalendarData = false;
 
     public void setNoCalendarData(boolean p) {
@@ -161,7 +162,6 @@ public class GenerateQuery {
 
             // if a list of properties is specified, then remove the allprop tag
             if (c.length > 1) {
-                allProp = false;
                 cl = c[1].trim().split("\\s*,\\s*");
                 this.requestedComponentProperties = Arrays.asList(cl);
             }
@@ -177,7 +177,7 @@ public class GenerateQuery {
     public void setComponent(String component, List<String> props) {
         if (component != null) {
             setRequestedComponent(component);
-            this.requestedComponentProperties = props;
+            this.requestedComponentProperties = Optional.ofNullable( props ).orElse( new ArrayList<>() );
         }
     }
 
@@ -377,7 +377,7 @@ public class GenerateQuery {
 
         CalendarQuery query = new CalendarQuery();
         query.addProperty(CalDAVConstants.DNAME_GETETAG);
-        if (allProp) {
+        if (isAllProp()) {
             query.addProperty(CalDAVConstants.DNAME_ALLPROP);
         }
         if (!noCalendarData) {
@@ -516,6 +516,14 @@ public class GenerateQuery {
         } catch (DOMException e) {
             throw new DOMValidationException(e.getMessage(), e);
         }
+    }
+    
+    /**
+     * Check whether all properties shall be retrieved
+     * @return <code>true</code> if no component properties are set
+     */
+    protected boolean isAllProp() {
+    	return this.requestedComponentProperties.isEmpty();
     }
 
     /**

--- a/src/test/java/com/github/caldav4j/util/GenerateQueryTest.java
+++ b/src/test/java/com/github/caldav4j/util/GenerateQueryTest.java
@@ -16,6 +16,7 @@
 
 package com.github.caldav4j.util;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.github.caldav4j.BaseTestCase;
@@ -26,9 +27,13 @@ import com.github.caldav4j.methods.PutGetTest;
 import com.github.caldav4j.model.request.*;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import net.fortuna.ical4j.model.Component;
 import net.fortuna.ical4j.model.DateTime;
+import net.fortuna.ical4j.model.Property;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -313,5 +318,29 @@ public class GenerateQueryTest extends BaseTestCase {
 
         s = XMLUtils.prettyPrint(gq.generate());
         log.info(s);
+    }
+    
+    @Test
+    public void testSetComponentProperties() {
+    	GenerateQuery generator = new GenerateQuery();
+    	generator.setComponent( Component.VEVENT );
+    	assertTrue( generator.isAllProp() );
+    	
+    	generator = new GenerateQuery();
+    	generator.setComponent( Component.VEVENT + ":" + Property.UID );
+    	generator.setComponent( Component.VEVENT );
+    	assertFalse( generator.isAllProp() );
+    	
+    	generator = new GenerateQuery();
+    	generator.setComponent( Component.VEVENT, null );
+    	assertTrue( generator.isAllProp() );
+    	
+    	generator = new GenerateQuery();
+    	generator.setComponent( Component.VEVENT, Collections.emptyList() );
+    	assertTrue( generator.isAllProp() );
+    	
+    	generator = new GenerateQuery();
+    	generator.setComponent( Component.VEVENT, Arrays.asList( Property.UID, Property.DTSTART ) );
+    	assertFalse( generator.isAllProp() );
     }
 }


### PR DESCRIPTION
The internal "allprop" property within the GenerateQuery class is only updated when using one of the two available methods to set a component. When using `setComponent(String)` and the provided string contains a list of properties, the tag is removed. However, when using `setComponent(String, List<String>)` to specify the properties manually, the tag is not updated.

This pull request fixes this bug by replacing the problematic field with an internal method for checking whether the tag should be set.