### PR TITLE
query generator: use allprop tag from CALDAV namespace instead of DAV

### DIFF
--- a/src/main/java/com/github/caldav4j/util/GenerateQuery.java
+++ b/src/main/java/com/github/caldav4j/util/GenerateQuery.java
@@ -190,11 +190,15 @@ public class GenerateQuery {
             Comp vEventComp = new Comp();
             vEventComp.setName(requestedComponent);
 
-            for (String propertyName : requestedComponentProperties) {
-                // add properties to VCALENDAR.VEVENT
-                vEventComp.addProp(
-                        new CalDAVProp(
-                                propertyName, false, false)); // @see modification to CalDAVProp
+            if (requestedComponentProperties.isEmpty()) {
+                vEventComp.setAllProp(true);
+            } else {
+                for (String propertyName : requestedComponentProperties) {
+                    // add properties to VCALENDAR.VEVENT
+                    vEventComp.addProp(
+                            new CalDAVProp(
+                                    propertyName, false, false)); // @see modification to CalDAVProp
+                }
             }
             // add only one component...maybe more ;)
             List<Comp> comps = new ArrayList<>();
@@ -206,7 +210,10 @@ public class GenerateQuery {
                 log.warn("Comp not valid");
             }
             vCalendarComp.setComps(comps);
+        } else {
+            vCalendarComp.setAllProp(true);
         }
+
         return vCalendarComp;
     }
 
@@ -377,9 +384,7 @@ public class GenerateQuery {
 
         CalendarQuery query = new CalendarQuery();
         query.addProperty(CalDAVConstants.DNAME_GETETAG);
-        if (allProp) {
-            query.addProperty(CalDAVConstants.DNAME_ALLPROP);
-        }
+
         if (!noCalendarData) {
             // TODO limit-recurrence-set
             CalendarData calendarData = new CalendarData();
@@ -392,6 +397,12 @@ public class GenerateQuery {
 
             query.setCalendarDataProp(calendarData);
         } else {
+            if (allProp) {
+                // only set the allprop tag if no calendar-data is included, otherwise it's
+                // set on the calendar-data comp if needed
+                query.addProperty(CalDAVConstants.DNAME_ALLPROP);
+            }
+
             if (this.recurrenceSetEnd != null || this.recurrenceSetStart != null) {
                 throw new CalDAV4JProtocolException(
                         "Bad query: you set noCalendarData but you have limit-recurrence-set");


### PR DESCRIPTION
This fixes issues with DAViCal servers. As the server does not handle the DAV allprop
nicely, this leads to issues for example when expanding recurring events.

## Detailed issue

Tested with _DAViCal r1.1.9.3_.

Given the following event which is stored in a calendar on the server:
```
BEGIN:VCALENDAR
PRODID:-//davical.org//NONSGML AWL Calendar//EN
VERSION:2.0
CALSCALE:GREGORIAN
X-WR-CALNAME:recurring
BEGIN:VEVENT
DTSTAMP:20201023T103404Z
DTSTART:20201101T090000Z
DURATION:PT1H
SUMMARY:Test Event
RRULE:FREQ=WEEKLY;COUNT=5;INTERVAL=2
UID:af35ab1d-67c3-465e-80dc-a8fe43a896a2
END:VEVENT
END:VCALENDAR
```

When issuing a query which requests expansion of the recurring event, as created by the GenerateQuery class:
```
<?xml version="1.0" encoding="utf-8" standalone="no"?>
<C:calendar-query xmlns:C="urn:ietf:params:xml:ns:caldav">
  <D:prop xmlns:D="DAV:">
    <D:getetag/>
    <D:allprop/>
    <C:calendar-data>
      <C:comp name="VCALENDAR"/>
      <C:expand end="20201231T000000Z" start="20201201T000000Z"/>
    </C:calendar-data>
  </D:prop>
  <C:filter>
    <C:comp-filter name="VCALENDAR">
      <C:comp-filter name="VEVENT">
        <C:time-range end="20201231T000000Z" start="20201201T000000Z"/>
      </C:comp-filter>
    </C:comp-filter>
  </C:filter>
</C:calendar-query>
```

The response includes only the master event, but no expanded events as it would be expected:
```
BEGIN:VCALENDAR
PRODID:-//NONSGML CalDAV4j Client//EN
VERSION:2.0
CALSCALE:GREGORIAN
BEGIN:VEVENT
DTSTAMP:20201023T103441Z
DTSTART:20201101T090000Z
DURATION:PT1H
SUMMARY:Test Event
RRULE:FREQ=WEEKLY;COUNT=5;INTERVAL=2
UID:edb8659f-50f8-4a3a-8e3a-09bba1e4c496
END:VEVENT
END:VCALENDAR
```

This seems to be related to the handling of the _allprop_ tag in the DAViCal server [here](https://gitlab.com/davical-project/davical/-/blob/r1.1.9.3/inc/caldav-REPORT.php#L169-206) and [here](https://gitlab.com/davical-project/davical/-/blob/r1.1.9.3/inc/caldav-REPORT.php#L210-214), which triggers some special case where it loads the master event to fulfil the request of returning all original properties and discards the already expanded data.

### Fix

By avoiding usage of the _allprop_ tag from the DAV namespace and using the _allprop_ tag from the CALDAV namespace on the _comp_ within the _calendar-data_ instead, events are reported as expected.

The modified query:
```
<?xml version="1.0" encoding="utf-8" standalone="no"?>
<C:calendar-query xmlns:C="urn:ietf:params:xml:ns:caldav">
  <D:prop xmlns:D="DAV:">
    <D:getetag/>
    <C:calendar-data>
      <C:comp name="VCALENDAR">
        <C:allprop/>
      </C:comp>
      <C:expand end="20201231T000000Z" start="20201201T000000Z"/>
    </C:calendar-data>
  </D:prop>
  <C:filter>
    <C:comp-filter name="VCALENDAR">
      <C:comp-filter name="VEVENT">
        <C:time-range end="20201231T000000Z" start="20201201T000000Z"/>
      </C:comp-filter>
    </C:comp-filter>
  </C:filter>
</C:calendar-query>
```
returns the expected result:
```
BEGIN:VCALENDAR
PRODID:-//NONSGML CalDAV4j Client//EN
VERSION:2.0
CALSCALE:GREGORIAN
BEGIN:VEVENT
DTSTAMP:20201023T103404Z
DURATION:PT1H
SUMMARY:Test Event
UID:af35ab1d-67c3-465e-80dc-a8fe43a896a2
DTSTART:20201213T090000Z
DURATION:PT1H
RECURRENCE-ID:20201213T090000Z
END:VEVENT
BEGIN:VEVENT
DTSTAMP:20201023T103404Z
DURATION:PT1H
SUMMARY:Test Event
UID:af35ab1d-67c3-465e-80dc-a8fe43a896a2
DTSTART:20201227T090000Z
DURATION:PT1H
RECURRENCE-ID:20201227T090000Z
END:VEVENT
END:VCALENDAR
```

As the issue may also effect other server implementations and is likely to be present in a wide range of DAViCal versions, plus it seems to be fixable by simply updating the style of the generated request to another valid format, I suppose it'd be appropriate to fix this issue in the client to ensure its compatibility with as many server implementations as possible.