### PR TITLE
How about add more Forked VM when run all tests in build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
               <exclude>**/*TestCase.java</exclude>
             </excludes>
             <threadCount>1</threadCount>
-            <forkCount>0</forkCount>
+            <forkCount>1.5C</forkCount>
             <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Xmx1024m</argLine>
             <useSystemClassLoader>false</useSystemClassLoader>
           </configuration>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
